### PR TITLE
Error in git tutorial

### DIFF
--- a/git-tutorial.markdown
+++ b/git-tutorial.markdown
@@ -157,7 +157,7 @@ connection):
 
 ```bash
 cd ~/alice/AliPhysics
-git remote add <your-github-username> git@github.com:<your-github-username>/AliPhysics
+git remote add <your-github-username> git@github.com:<your-github-username>/AliPhysics.git
 ```
 
 If you do not use SSH:


### PR DESCRIPTION
There is an error in our git tutorial. The `.git` in the ssh url is missing. 