### PR TITLE
Update aurora build instructions

### DIFF
--- a/infrastructure-aurora.markdown
+++ b/infrastructure-aurora.markdown
@@ -18,7 +18,7 @@ of the pull request.
 Access is allowed to ALICE members who are part of the
 [`alice-aurora-users`](https://e-groups.cern.ch/e-groups/Egroup.do?egroupId=10225666) **and** of the [`alice-agile-admin`](https://e-groups.cern.ch/e-groups/Egroup.do?egroupId=10172645) egroups.
 
-If you have toubles following the instructions, in particular if you have certificate or kerberos issues, please make sure you read the [Troubleshooting](#troubleshooting) section.
+If you have troubles following the instructions, in particular if you have certificate or kerberos issues, please make sure you read the [Troubleshooting](#troubleshooting) section.
 
 # User guide
 
@@ -34,9 +34,8 @@ The GUI is only a read-only view on the state of the jobs
 running on the cluster. If you want to interact with Aurora
 itself you will need the aurora client.
 
-You can get a binary distribution of the Aurora client at:
-
-<https://github.com/alisw/aurora/releases/tag/0.16.0-alice2>
+You can get a binary distribution of the Aurora client at
+<https://github.com/alisw/aurora/releases>.
 
 Alternatively you can download the sources and build it with:
 
@@ -79,18 +78,20 @@ Aug 13 14:26:57 2019  Aug 14 00:26:57 2019  krbtgt/CERN.CH@CERN.CH
 In order to reach the Aurora cluster, you need to configure how to
 access it. This is done by creating a file `~/.aurora/clusters.json`:
 
-    [{
-      "name": "build",
-      "scheduler_uri": "https://aliaurora.cern.ch",
-      "auth_mechanism": "KERBEROS",
-      "slave_run_directory": "latest",
-      "slave_root": "/build/mesos"
-    }]
+```json
+[{
+  "name": "build",
+  "scheduler_uri": "https://aliaurora.cern.ch",
+  "auth_mechanism": "KERBEROS",
+  "slave_run_directory": "latest",
+  "slave_root": "/build/mesos"
+}]
+```
 
 If everything is setup as expected you should be able to get a list of
 jobs by doing:
 
-```
+```bash
 $ aurora job list build
 ```
 

--- a/infrastructure-aurora.markdown
+++ b/infrastructure-aurora.markdown
@@ -37,11 +37,21 @@ itself you will need the aurora client.
 You can get a binary distribution of the Aurora client at
 <https://github.com/alisw/aurora/releases>.
 
-Alternatively you can download the sources and build it with:
+Alternatively, to build from source, download the source tarball associated with
+the release you need and follow the instructions to build the client below. Note
+that at the time of writing, `master` points to an ancient commit, so if you're
+building from the sources in the git repository, first do: `git checkout
+0.16.0-alice3` (or whichever version you need).
 
 ```bash
+# Build the aurora binary:
 ./pants binary src/main/python/apache/aurora/kerberos:kaurora
-cp dist/kaurora aurora
+# If you need the aurora_admin binary:
+./pants binary src/main/python/apache/aurora/kerberos:kaurora_admin
+# Copy it somewhere in your $PATH.
+cp dist/kaurora.pex ~/.local/bin/aurora
+# If you built aurora_admin above:
+cp dist/kaurora_admin.pex ~/.local/bin/aurora_admin
 ```
 
 If you use homebrew, you can also do:


### PR DESCRIPTION
Most importantly, I've added build instructions for the `aurora_admin` binary.

I also fixed a few minor things: a typo, link and code block formatting.