### PR TITLE
Document docker images process

### DIFF
--- a/infrastructure-alibi-user-guide.markdown
+++ b/infrastructure-alibi-user-guide.markdown
@@ -5,12 +5,12 @@ categories: infrastructure
 ---
 
 
-The **Ali**ce **B**enchmark **I**nfrastructure is a service that was established to provide a platform for systematic, reproducable and consistent benchmarks for ALICE O2.
+The **Ali**ce **B**enchmark **I**nfrastructure is a service that was established to provide a platform for systematic, reproducible and consistent benchmarks for ALICE O2.
 
 Its primary task is to provide automated performance regression testing for simulation and reconstruction nightlies, however it is open to developers for their own **benchmarking** tasks within extended CERN working hours.
 
 ## Hardware
-For the sake of reproducable results, a physical server (compute node) has been aquired:
+For the sake of reproducible results, a physical server (compute node) has been acquired:
 * 2x Xeon Gold 6132 (2.6GHz, 14Core each)
 * 384GB ECC DDR4-2666 RAM
 * Nvidia Geforce RTX 2080 (8GB GDDR5)
@@ -121,13 +121,13 @@ This is your local home directory. Data is kept and users will be asked to clean
 ```
 $SCRATCH=/tmp/$USER
 ```
-This is a temporary directory which will be cleared out regularly without prior anouncement
+This is a temporary directory which will be cleared out regularly without prior announcement
 
 ### Can I use SSH keys?
 Yes but just as with `lxplus` you will get any Kerberos, AFS and eos token which will cause access issues including no access (neither read nor write) to your home directory
 
 ### I Cannot Read/Write to AFS or EOS
-You probably logged in with a `ssh` key or your ssh is missconfigured. 
+You probably logged in with a `ssh` key or your ssh is misconfigured. 
 To check the state of your Kerberos cache use `klist`. If it complains about an empty credentials cache:
 ```bash
 -bash-4.2$ klist
@@ -139,7 +139,7 @@ issue the following commands:
 * `aklog`: request/renew afs token
 * `eosfusebind`: sets up eos directories
 
-After this opperation your kerberos cache should look like this 
+After this operation your kerberos cache should look like this 
 ```
 -bash-4.2$ klist
 Ticket cache: FILE:/tmp/krb5cc_101957

--- a/infrastructure-docker-packer.md
+++ b/infrastructure-docker-packer.md
@@ -1,0 +1,56 @@
+---
+title: ALICE Docker images
+layout: main
+categories: infrastructure
+---
+
+Most of our [CI Jobs][ci-jobs] running on Nomad are containerized via Docker to
+ensure reproducibility between builds.
+
+The docker image definitions are available in
+[alisw/docks](https://github.com/alisw/docks), and the CERN docker registry is
+<https://registry.cern.ch/>
+
+
+# Rebuilding a Docker image
+
+If an image definition has changed, it must be rebuilt and pushed to the proper
+registry for Nomad to use it in new job allocations.
+
+
+## Packer-defined images
+
+Newer images have a ``packer.json`` file, which allows them to be built using
+Hashicorp packer. This has the nice advantage that we can customize and upload
+the images in one go. 
+
+There's a [GitHub Action
+here](https://github.com/alisw/docks/actions/workflows/push-docker-image.yml)
+that will rebuild and push the images for you.
+
+In case you prefer to do it manually:
+
+```bash
+brew install packer # > 0.10.0
+cd <image-name>
+packer build packer.json
+```
+
+If you don't want to upload the finished image to DockerHub (e.g. if you're just
+testing changes to the image, or you don't have the rights to upload), remove
+the `"docker-push"` entry from `"post-processors"` in the `packer.json` you're
+using. (JSON doesn't allow trailing commas in arrays, so don't forget to remove
+the comma as well!)
+
+## Dockerfile-defined images
+
+Older images without a `packer.json` can be built with:
+
+```bash
+docker build -t alisw/<image-name> <image-name>
+```
+
+
+[ci-jobs]: https://github.com/alisw/ci-jobs
+[packer]: https://www.packer.io/
+

--- a/infrastructure-logs.md
+++ b/infrastructure-logs.md
@@ -7,7 +7,7 @@ categories: infrastructure
 Logs for the PRs are now copied on the [CERN S3](https://clouddocs.web.cern.ch/object_store/index.html) object store.
 They are accessible either via the read only web interface at:
 
-https://ali-ci.cern.ch/alice-build-logs/
+<https://ali-ci.cern.ch/alice-build-logs/>
 
 which is an SSO protected url exposed by machines in the `alibuild/frontend` puppet hostgroup or via the
 `s3://alice-build-logs` endpoint, which provides read-write capabilities.

--- a/infrastructure.markdown
+++ b/infrastructure.markdown
@@ -29,6 +29,7 @@ Further troubleshooting information is privately available in the repository:
 * <a href="{{site.baseurl}}/infrastructure-auto-builds">Setting up automatic release builds</a>
 * <a href="{{site.baseurl}}/infrastructure-rpms">Generation of RPMs</a>
 * <a href="{{site.baseurl}}/infrastructure-known-tradeoffs">Known tradeoffs</a>
+* [Building Docker images with Packer]({{site.baseurl}}/infrastructure-docker-packer)
 
 ## Infrastructure
 

--- a/side-menu.css
+++ b/side-menu.css
@@ -40,7 +40,7 @@ The content `<div>` is where all your content goes.
 */
 .content {
     margin: 0 auto;
-    padding: 0 2em;
+    padding: 2em 2em;
     max-width: 800px;
     margin-bottom: 50px;
     line-height: 1.6em;


### PR DESCRIPTION
Mostly copied the README from the docks repo, in order to centralize the docs here.

https://github.com/alisw/docks/blob/3bc71296c9956912cc8d43a24e97eabdb3c8344d/README.md
